### PR TITLE
Create libapparmor-3.0.4-fix-cflags-and-ldflags.patch

### DIFF
--- a/sys-libs/libapparmor/libapparmor-3.0.4-fix-cflags-and-ldflags.patch
+++ b/sys-libs/libapparmor/libapparmor-3.0.4-fix-cflags-and-ldflags.patch
@@ -1,0 +1,20 @@
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -38,7 +38,7 @@
+ BUILT_SOURCES = grammar.h scanner.h af_protos.h
+ AM_LFLAGS = -v
+ AM_YFLAGS = -d -p aalogparse_
+-AM_CFLAGS = -Wall $(EXTRA_WARNINGS) -fPIC -flto-partition=none
++AM_CFLAGS = -Wall $(EXTRA_WARNINGS) -fPIC
+ AM_CPPFLAGS = -D_GNU_SOURCE -I$(top_srcdir)/include/
+ scanner.h: scanner.l
+        $(LEX) -v $<
+@@ -53,7 +53,7 @@
+ 
+ libapparmor_la_SOURCES = grammar.y libaalogparse.c kernel.c scanner.c private.c features.c kernel_interface.c policy_cache.c PMurHash.c
+ libapparmor_la_LDFLAGS = -version-info $(AA_LIB_CURRENT):$(AA_LIB_REVISION):$(AA_LIB_AGE) -XCClinker -dynamic -pthread \
+-       -Wl,--version-script=$(top_srcdir)/src/libapparmor.map
++       -Wl,--version-script=$(top_srcdir)/src/libapparmor.map --lto-O3
+ 
+ pkgconfigdir = $(libdir)/pkgconfig
+ pkgconfig_DATA = libapparmor.pc


### PR DESCRIPTION
Necessary for libapparmor to compile and run.