### PR TITLE
add iproute2 clang+lto fix

### DIFF
--- a/sys-apps/iproute2/iproute2-5.19.0-include-sys-param-header-for-MIN-macro.patch
+++ b/sys-apps/iproute2/iproute2-5.19.0-include-sys-param-header-for-MIN-macro.patch
@@ -1,0 +1,10 @@
+diff --git a/ip/ipstats.c b/ip/ipstats.c
+index 5cdd15a..91620cd 100644
+--- a/ip/ipstats.c
++++ b/ip/ipstats.c
+@@ -1,4 +1,5 @@
+ // SPDX-License-Identifier: GPL-2.0+
++#include <sys/param.h>
+ #include <assert.h>
+ #include <errno.h>
+ 


### PR DESCRIPTION
a patch for
```
ld.lld: error: undefined symbol: MIN
>>> referenced by ipstats.c
>>>               lto.tmp:(ipstats_stat_desc_show_link)
>>> referenced by ipstats.c
>>>               lto.tmp:(ipstats_stat_desc_show_cpu_hit)
>>> referenced by ipstats.c
>>>               lto.tmp:(ipstats_stat_desc_show_l3_stats)
>>> referenced 1 more times
clang-14: error: linker command failed with exit code 1 (use -v to see invocation)
```
in sys-apps/iproute2