### PR TITLE
app-text/tree: remove duplicate object file

### DIFF
--- a/app-text/tree/tree-2.0.2-fix-lto-remove-duplicate-object-file.patch
+++ b/app-text/tree/tree-2.0.2-fix-lto-remove-duplicate-object-file.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index a102b82..6c215e2 100644
+--- a/Makefile
++++ b/Makefile
+@@ -27,7 +27,7 @@ DESTDIR=${PREFIX}/bin
+ MAN=tree.1
+ # Probably needs to be ${PREFIX}/share/man for most systems now
+ MANDIR=${PREFIX}/man
+-OBJS=tree.o list.o hash.o color.o file.o filter.o info.o unix.o xml.o json.o html.o strverscmp.o strverscmp.o
++OBJS=tree.o list.o hash.o color.o file.o filter.o info.o unix.o xml.o json.o html.o strverscmp.o
+
+ # Uncomment options below for your particular OS:
+


### PR DESCRIPTION
A patch for
```
ld.lld: error: Expected at most one ThinLTO module per bitcode file
clang-14: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [Makefile:97: tree] Error 1
```
in **app-text/tree-2.0.2::gentoo**