### PR TITLE
sys-apps/flashrom: fix build due to mismatch signature

### DIFF
--- a/dev-perl/Tk/deprecated-signature-mismatch-fix.patch
+++ b/dev-perl/Tk/deprecated-signature-mismatch-fix.patch
@@ -1,0 +1,32 @@
+--- Tk-804.036/pTk/Xlib.t.orig
++++ Tk-804.036/pTk/Xlib.t
+@@ -331,7 +331,7 @@
+ #endif /* !DO_X_EXCLUDE */
+
+ #ifndef XKeycodeToKeysym
+-VFUNC(KeySym,XKeycodeToKeysym,V_XKeycodeToKeysym,_ANSI_ARGS_((Display *, unsigned int, int)))
++VFUNC(KeySym,(KeySym (*)(Display *, unsigned int, int)) XKeycodeToKeysym,V_XKeycodeToKeysym,_ANSI_ARGS_((Display *, unsigned int, int)))
+ #endif /* #ifndef XKeycodeToKeysym */
+
+ #ifndef XKeysymToString
+--- Tk-804.036/pTk/tkIntXlibDecls.t.orig
++++ Tk-804.036/pTk/tkIntXlibDecls.t
+@@ -745,15 +745,15 @@
+ 
+ #ifndef XKeycodeToKeysym
+ #ifdef MAC_OSX_TK
+-VFUNC(KeySym,XKeycodeToKeysym,V_XKeycodeToKeysym,_ANSI_ARGS_((Display* d, KeyCode k,
++VFUNC(KeySym,(KeySym (*)(Display *, unsigned int, int))XKeycodeToKeysym,V_XKeycodeToKeysym,_ANSI_ARGS_((Display* d, KeyCode k,
+ 				int i)))
+ #endif /* #ifdef MAC_OSX_TK */
+ #ifdef MAC_TCL
+-VFUNC(KeySym,XKeycodeToKeysym,V_XKeycodeToKeysym,_ANSI_ARGS_((Display* d, KeyCode k,
++VFUNC(KeySym,(KeySym (*)(Display *, unsigned int, int))XKeycodeToKeysym,V_XKeycodeToKeysym,_ANSI_ARGS_((Display* d, KeyCode k,
+ 				int i)))
+ #endif /* #ifdef MAC_TCL */
+ #ifdef __WIN32__
+-VFUNC(KeySym,XKeycodeToKeysym,V_XKeycodeToKeysym,_ANSI_ARGS_((Display* d,
++VFUNC(KeySym,(KeySym (*)(Display *, unsigned int, int))XKeycodeToKeysym,V_XKeycodeToKeysym,_ANSI_ARGS_((Display* d,
+ 				unsigned int k, int i)))
+ #endif /* #ifdef __WIN32__ */
+ #endif /* #ifndef XKeycodeToKeysym */

--- a/sys-apps/flashrom/clang-16-incompatible-function-pointer-fix.patch
+++ b/sys-apps/flashrom/clang-16-incompatible-function-pointer-fix.patch
@@ -1,0 +1,22 @@
+--- flashrom-v1.3.0/dummyflasher.c.orig
++++ flashrom-v1.3.0/dummyflasher.c
+@@ -122,7 +122,7 @@
+ 				emu_data->spi_write_256_chunksize);
+ }
+ 
+-static bool dummy_spi_probe_opcode(struct flashctx *flash, uint8_t opcode)
++static bool dummy_spi_probe_opcode(const struct flashctx *flash, uint8_t opcode)
+ {
+ 	size_t i;
+ 	struct emu_data *emu_data = flash->mst->spi.data;
+--- flashrom-v1.3.0/ichspi.c.orig
++++ flashrom-v1.3.0/ichspi.c
+@@ -1661,7 +1661,7 @@
+ 	return ret;
+ }
+ 
+-static bool ich_spi_probe_opcode(struct flashctx *flash, uint8_t opcode)
++static bool ich_spi_probe_opcode(const struct flashctx *flash, uint8_t opcode)
+ {
+ 	return find_opcode(curopcodes, opcode) >= 0;
+ }


### PR DESCRIPTION
clang 16 is quite pedantic with the -Wincompatible-function-pointer-types flag. this patch fixes sources to make two functions become const structs instead of non-const