### PR TITLE
app-emulation/qemu stole patch from alpine to fix the compilation on musl

### DIFF
--- a/app-emulation/qemu/lfs64.patch
+++ b/app-emulation/qemu/lfs64.patch
@@ -1,0 +1,204 @@
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index bbba2a6..38fa09a 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -6812,13 +6812,13 @@ static int target_to_host_fcntl_cmd(int cmd)
+         ret = cmd;
+         break;
+     case TARGET_F_GETLK:
+-        ret = F_GETLK64;
++        ret = F_GETLK;
+         break;
+     case TARGET_F_SETLK:
+-        ret = F_SETLK64;
++        ret = F_SETLK;
+         break;
+     case TARGET_F_SETLKW:
+-        ret = F_SETLKW64;
++        ret = F_SETLKW;
+         break;
+     case TARGET_F_GETOWN:
+         ret = F_GETOWN;
+@@ -6834,13 +6834,13 @@ static int target_to_host_fcntl_cmd(int cmd)
+         break;
+ #if TARGET_ABI_BITS == 32
+     case TARGET_F_GETLK64:
+-        ret = F_GETLK64;
++        ret = F_GETLK;
+         break;
+     case TARGET_F_SETLK64:
+-        ret = F_SETLK64;
++        ret = F_SETLK;
+         break;
+     case TARGET_F_SETLKW64:
+-        ret = F_SETLKW64;
++        ret = F_SETLKW;
+         break;
+ #endif
+     case TARGET_F_SETLEASE:
+@@ -6894,8 +6894,8 @@ static int target_to_host_fcntl_cmd(int cmd)
+      * them to 5, 6 and 7 before making the syscall(). Since we make the
+      * syscall directly, adjust to what is supported by the kernel.
+      */
+-    if (ret >= F_GETLK64 && ret <= F_SETLKW64) {
+-        ret -= F_GETLK64 - 5;
++    if (ret >= F_GETLK && ret <= F_SETLKW) {
++        ret -= F_GETLK - 5;
+     }
+ #endif
+ 
+@@ -6928,7 +6928,7 @@ static int host_to_target_flock(int type)
+     return type;
+ }
+ 
+-static inline abi_long copy_from_user_flock(struct flock64 *fl,
++static inline abi_long copy_from_user_flock(struct flock *fl,
+                                             abi_ulong target_flock_addr)
+ {
+     struct target_flock *target_fl;
+@@ -6953,7 +6953,7 @@ static inline abi_long copy_from_user_flock(struct flock64 *fl,
+ }
+ 
+ static inline abi_long copy_to_user_flock(abi_ulong target_flock_addr,
+-                                          const struct flock64 *fl)
++                                          const struct flock *fl)
+ {
+     struct target_flock *target_fl;
+     short l_type;
+@@ -6972,8 +6972,8 @@ static inline abi_long copy_to_user_flock(abi_ulong target_flock_addr,
+     return 0;
+ }
+ 
+-typedef abi_long from_flock64_fn(struct flock64 *fl, abi_ulong target_addr);
+-typedef abi_long to_flock64_fn(abi_ulong target_addr, const struct flock64 *fl);
++typedef abi_long from_flock64_fn(struct flock *fl, abi_ulong target_addr);
++typedef abi_long to_flock64_fn(abi_ulong target_addr, const struct flock *fl);
+ 
+ #if defined(TARGET_ARM) && TARGET_ABI_BITS == 32
+ struct target_oabi_flock64 {
+@@ -6984,7 +6984,7 @@ struct target_oabi_flock64 {
+     abi_int   l_pid;
+ } QEMU_PACKED;
+ 
+-static inline abi_long copy_from_user_oabi_flock64(struct flock64 *fl,
++static inline abi_long copy_from_user_oabi_flock64(struct flock *fl,
+                                                    abi_ulong target_flock_addr)
+ {
+     struct target_oabi_flock64 *target_fl;
+@@ -7009,7 +7009,7 @@ static inline abi_long copy_from_user_oabi_flock64(struct flock64 *fl,
+ }
+ 
+ static inline abi_long copy_to_user_oabi_flock64(abi_ulong target_flock_addr,
+-                                                 const struct flock64 *fl)
++                                                 const struct flock *fl)
+ {
+     struct target_oabi_flock64 *target_fl;
+     short l_type;
+@@ -7029,7 +7029,7 @@ static inline abi_long copy_to_user_oabi_flock64(abi_ulong target_flock_addr,
+ }
+ #endif
+ 
+-static inline abi_long copy_from_user_flock64(struct flock64 *fl,
++static inline abi_long copy_from_user_flock64(struct flock *fl,
+                                               abi_ulong target_flock_addr)
+ {
+     struct target_flock64 *target_fl;
+@@ -7054,7 +7054,7 @@ static inline abi_long copy_from_user_flock64(struct flock64 *fl,
+ }
+ 
+ static inline abi_long copy_to_user_flock64(abi_ulong target_flock_addr,
+-                                            const struct flock64 *fl)
++                                            const struct flock *fl)
+ {
+     struct target_flock64 *target_fl;
+     short l_type;
+@@ -7075,7 +7075,7 @@ static inline abi_long copy_to_user_flock64(abi_ulong target_flock_addr,
+ 
+ static abi_long do_fcntl(int fd, int cmd, abi_ulong arg)
+ {
+-    struct flock64 fl64;
++    struct flock fl64;
+ #ifdef F_GETOWN_EX
+     struct f_owner_ex fox;
+     struct target_f_owner_ex *target_fox;
+@@ -7347,7 +7347,7 @@ static inline abi_long target_truncate64(CPUArchState *cpu_env, const char *arg1
+         arg2 = arg3;
+         arg3 = arg4;
+     }
+-    return get_errno(truncate64(arg1, target_offset64(arg2, arg3)));
++    return get_errno(truncate(arg1, target_offset64(arg2, arg3)));
+ }
+ #endif
+ 
+@@ -7361,7 +7361,7 @@ static inline abi_long target_ftruncate64(CPUArchState *cpu_env, abi_long arg1,
+         arg2 = arg3;
+         arg3 = arg4;
+     }
+-    return get_errno(ftruncate64(arg1, target_offset64(arg2, arg3)));
++    return get_errno(ftruncate(arg1, target_offset64(arg2, arg3)));
+ }
+ #endif
+ 
+@@ -8597,7 +8597,7 @@ static int do_getdents(abi_long dirfd, abi_long arg2, abi_long count)
+     void *tdirp;
+     int hlen, hoff, toff;
+     int hreclen, treclen;
+-    off64_t prev_diroff = 0;
++    off_t prev_diroff = 0;
+ 
+     hdirp = g_try_malloc(count);
+     if (!hdirp) {
+@@ -8650,7 +8650,7 @@ static int do_getdents(abi_long dirfd, abi_long arg2, abi_long count)
+              * Return what we have, resetting the file pointer to the
+              * location of the first record not returned.
+              */
+-            lseek64(dirfd, prev_diroff, SEEK_SET);
++            lseek(dirfd, prev_diroff, SEEK_SET);
+             break;
+         }
+ 
+@@ -8684,7 +8684,7 @@ static int do_getdents64(abi_long dirfd, abi_long arg2, abi_long count)
+     void *tdirp;
+     int hlen, hoff, toff;
+     int hreclen, treclen;
+-    off64_t prev_diroff = 0;
++    off_t prev_diroff = 0;
+ 
+     hdirp = g_try_malloc(count);
+     if (!hdirp) {
+@@ -8726,7 +8726,7 @@ static int do_getdents64(abi_long dirfd, abi_long arg2, abi_long count)
+              * Return what we have, resetting the file pointer to the
+              * location of the first record not returned.
+              */
+-            lseek64(dirfd, prev_diroff, SEEK_SET);
++            lseek(dirfd, prev_diroff, SEEK_SET);
+             break;
+         }
+ 
+@@ -11157,7 +11157,7 @@ static abi_long do_syscall1(CPUArchState *cpu_env, int num, abi_long arg1,
+                 return -TARGET_EFAULT;
+             }
+         }
+-        ret = get_errno(pread64(arg1, p, arg3, target_offset64(arg4, arg5)));
++        ret = get_errno(pread(arg1, p, arg3, target_offset64(arg4, arg5)));
+         unlock_user(p, arg2, ret);
+         return ret;
+     case TARGET_NR_pwrite64:
+@@ -11174,7 +11174,7 @@ static abi_long do_syscall1(CPUArchState *cpu_env, int num, abi_long arg1,
+                 return -TARGET_EFAULT;
+             }
+         }
+-        ret = get_errno(pwrite64(arg1, p, arg3, target_offset64(arg4, arg5)));
++        ret = get_errno(pwrite(arg1, p, arg3, target_offset64(arg4, arg5)));
+         unlock_user(p, arg2, 0);
+         return ret;
+ #endif
+@@ -12034,7 +12034,7 @@ static abi_long do_syscall1(CPUArchState *cpu_env, int num, abi_long arg1,
+     case TARGET_NR_fcntl64:
+     {
+         int cmd;
+-        struct flock64 fl;
++        struct flock fl;
+         from_flock64_fn *copyfrom = copy_from_user_flock64;
+         to_flock64_fn *copyto = copy_to_user_flock64;
+ 


### PR DESCRIPTION
I ~stole~ _forked_ this patch: https://git.alpinelinux.org/aports/tree/community/qemu/lfs64.patch?h=3.19-stable to make it compile on musl since before it threw errors 